### PR TITLE
#38 Add `requestLegacyExternalStorage` to keep support for `file://` Uris

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,12 +21,20 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
+    <!--
+        Note about requestLegacyExternalStorage: since the app will make no sense from Android 11
+        onwards (since we can no longer pick a camera app other than the system one from
+        ACTION_IMAGE_CAPTURE intents) we can take advantage of it and use the flag since it'll work
+        in Android 10 devices even if we update the targetSdkVersion.
+        Hope the big guys don't send me a warning about this.
+    -->
     <application
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher"
         android:theme="@style/AppTheme"
+        android:requestLegacyExternalStorage="true"
         tools:ignore="GoogleAppIndexingWarning">
 
         <!-- Activities -->

--- a/app/src/main/kotlin/com/adriangl/pict2cam/imagepicker/ImagePickerActivity.kt
+++ b/app/src/main/kotlin/com/adriangl/pict2cam/imagepicker/ImagePickerActivity.kt
@@ -33,6 +33,7 @@ import com.adriangl.pict2cam.extensions.getImageCaptureOutputUri
 import com.adriangl.pict2cam.extensions.isImageCaptureAction
 import com.adriangl.pict2cam.utils.ImageConstants
 import com.theartofdev.edmodo.cropper.CropImage
+import com.theartofdev.edmodo.cropper.CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE
 
 /**
  * Picker activity needed to receive the result of the media query to return it to the original
@@ -92,6 +93,11 @@ class ImagePickerActivity : AppCompatActivity() {
                     finish()
                 }
             }
+        } else if (resultCode == CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE) {
+            Toast.makeText(this, R.string.crop_image_activity_result_error, Toast.LENGTH_LONG)
+                    .show()
+            setResult(Activity.RESULT_CANCELED)
+            finish()
         } else {
             setResult(Activity.RESULT_CANCELED)
             finish()

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -32,4 +32,5 @@
     <string name="image_picker_chooser_title">"Elige una aplicación para seleccionar fotos"</string>
     <string name="image_picker_write_external_rationale_message">"Confirma que permites que la aplicación puede escribir en almacenamiento externo. Este permiso es necesario para que la aplicación funcione correctamente"</string>
     <string name="image_picker_write_external_rationale_action_allow">"Permitir"</string>
+    <string name="crop_image_activity_result_error">"Ha ocurrido un error al redimensionar la imagen"</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,5 +32,5 @@
     <string name="image_picker_chooser_title">"Select an app to pick images"</string>
     <string name="image_picker_write_external_rationale_message">"Confirm that you allow the app to write to external storage. This permission is needed for the app to work properly"</string>
     <string name="image_picker_write_external_rationale_action_allow">"Allow"</string>
-
+    <string name="crop_image_activity_result_error">"There has been an error while resizing the image"</string>
 </resources>


### PR DESCRIPTION
### Github issue (delete if this does not apply)
Resolves #38 

### PR's key points
As the linked issue suggest, I added the `requestLegacyExternalStorage` flag to `true` in `AndroidManifest.xml`. I also added a bit of context to errors within the crop activity.
 
### Related Issues (delete if this does not apply)
 
### Definition of Done
- [ ] Tests added (if new code is added)
- [ ] There is no outcommented or debug code left