### PR TITLE
(#64) Set crop area to full image by default

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,23 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="io.ktor" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
-    </JetCodeStyleSettings>
     <codeStyleSettings language="XML">
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/app/src/main/kotlin/com/adriangl/pict2cam/imagepicker/ImagePickerActivity.kt
+++ b/app/src/main/kotlin/com/adriangl/pict2cam/imagepicker/ImagePickerActivity.kt
@@ -107,6 +107,8 @@ class ImagePickerActivity : AppCompatActivity() {
     override fun onRequestPermissionsResult(requestCode: Int,
                                             permissions: Array<String>,
                                             grantResults: IntArray) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+
         when (requestCode) {
             WRITE_EXTERNAL_STORAGE_PERMISSION_REQUEST_CODE ->
                 if (grantResults.getOrNull(0) == PackageManager.PERMISSION_GRANTED) {
@@ -180,6 +182,8 @@ class ImagePickerActivity : AppCompatActivity() {
 
     private fun openImageCropper(imageUri: Uri, outputUri: Uri) {
         CropImage.activity(imageUri)
+                // Set crop to full size by default
+                .setInitialCropWindowPaddingRatio(0f)
                 // Image quality
                 .setOutputCompressFormat(ImageConstants.DEFAULT_COMPRESS_FORMAT)
                 .setOutputCompressQuality(ImageConstants.DEFAULT_IMAGE_QUALITY)


### PR DESCRIPTION
### Github issue (delete if this does not apply)
Resolves #64

### PR's key points
The PR sets the crop area to the full size of the image by default.
 
### Definition of Done
- [ ] Tests added (if new code is added)
- [x] There is no outcommented or debug code left